### PR TITLE
Modified buttons and text in Game State to match game aesthetic

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -171,7 +171,20 @@
   cursor: pointer;
 }
 
-.turnInfo {
+.domino-input {
+  padding: 10px 20px;
+  font-family: 'Press Start 2P', sans-serif;
+  font-size: 10px;
+  background-color: #FFFEC9; 
+  border: none;
+  margin: 1px;
+  border-radius: 5px;
+  color: #582400; 
+  cursor: pointer;
+  width: 220px;
+}
+
+.turnInfo, .main-text {
   font-family: 'Press Start 2P', sans-serif;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -158,3 +158,24 @@
 .chat-button:hover {
   background-color: rgb(244, 213, 75); 
 }
+
+.game-button {
+  padding: 10px 20px;
+  font-family: 'Press Start 2P', sans-serif;
+  font-size: 10px;
+  background-color: #FFFEC9; 
+  border: none;
+  margin: 1px;
+  border-radius: 5px;
+  color: #582400; 
+  cursor: pointer;
+}
+
+.turnInfo {
+  font-family: 'Press Start 2P', sans-serif;
+}
+
+.volume {
+  font-family: 'Press Start 2P', sans-serif;
+  font-size: 20px;
+}

--- a/frontend/src/gamestate/experimentalGame.js
+++ b/frontend/src/gamestate/experimentalGame.js
@@ -727,7 +727,7 @@ function MainGame() {
 
                     {/* Display the scores with inline styling */}
                     {gameMode === 'allFives' && (
-                    <div style={{
+                    <div className= 'main-text' style={{
                         position: 'absolute',
                         top: '50px',
                         left: '20px',
@@ -753,7 +753,7 @@ function MainGame() {
                     )}
 
                     {playingDraw && (
-                        <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                        <div className='main-text' style={{ display: 'flex', justifyContent: 'space-between'}}>
                             <ScoreTracker temp_score={playerScore} message={"Player score is: "} />
                             <ScoreTracker temp_score={botScore} message={"Bot score is: "} />
                         </div>
@@ -792,10 +792,10 @@ function MainGame() {
                         <div className='Player1'>
                             <p>{playerData.DrawHand}</p>
 
-                            <input className='game-button' type='number'
+                            <input className='domino-input' type='number'
                                 value={playerDominoIndex}
                                 onChange={(e) => setPlayerDominoIndex(e.target.value)}
-                                placeholder='Enter the position of a domino' />
+                                placeholder='Enter domino position' />
 
                             <button className='game-button' onClick={() => {
                                 if (playerDominoIndex) {

--- a/frontend/src/gamestate/experimentalGame.js
+++ b/frontend/src/gamestate/experimentalGame.js
@@ -43,10 +43,11 @@ function MainGame() {
       
         return (
           <div>
-            <button onClick={togglePlay}>
+            <button className='game-button' onClick={togglePlay}>
               {isPlaying ? 'Pause background music...' : 'Press for background music!'}
             </button>
-            <label>
+            <div>
+            <label className='volume'>
               Volume:
               <input
                 type="range"
@@ -57,6 +58,7 @@ function MainGame() {
                 onChange={handleVolumeChange}
               />
             </label>
+            </div>
           </div>
         );
       };
@@ -790,12 +792,12 @@ function MainGame() {
                         <div className='Player1'>
                             <p>{playerData.DrawHand}</p>
 
-                            <input type='number'
+                            <input className='game-button' type='number'
                                 value={playerDominoIndex}
                                 onChange={(e) => setPlayerDominoIndex(e.target.value)}
                                 placeholder='Enter the position of a domino' />
 
-                            <button onClick={() => {
+                            <button className='game-button' onClick={() => {
                                 if (playerDominoIndex) {
                                     setData({
                                         Domino: playerData.PlayerHand[playerDominoIndex],
@@ -803,7 +805,7 @@ function MainGame() {
                                     });
                                 }
                             }}>Left Tail</button>
-                            <button onClick={() => {
+                            <button className='game-button' onClick={() => {
                                 if (playerDominoIndex) {
                                     setData({
                                         Domino: playerData.PlayerHand[playerDominoIndex],
@@ -811,7 +813,7 @@ function MainGame() {
                                     });
                                 }
                             }}>Right Tail</button>
-                            <button onClick={() => {
+                            <button className='game-button' onClick={() => {
                                 if (tableData.TableState.availableDominos <= 0) {
                                     setShowPopup(true);
                                     setTimeout(() => setShowPopup(false), 3000); // Hide popup after 3 seconds
@@ -823,12 +825,12 @@ function MainGame() {
                                     });
                                 }
                             }}>Grab a Random Chip</button>
-                            <button onClick={() => {
+                            <button className='game-button' onClick={() => {
                                 if(tableData.TableState.dominoesOnTable > 0){
                                     setPassButton(true);
                                 }
                             }}>Pass Turn</button>
-                            <button onClick={pauseGame}>Pause Game</button>
+                            <button className='game-button' onClick={pauseGame}>Pause Game</button>
                             <BackgroundMusic src={"/BackgroundMusic.mp3"}/> 
                         </div>
                     </div>


### PR DESCRIPTION
### **Made the following changes to the Game State:**

- Modified the main game control buttons to match with the rest of the game of aesthetic; previously the buttons had a basic appearance that did not reflect the playful nature of the game.
- Modified the font of non-button main text such as "Volume" and the Player and Bot turn text indicators. Both now follow the pixelated aesthetic using font "Press Start 2P"
- Changed the organization of the volume and music buttons near the bottom of the page. Now the Volume text and slider are underneath the control buttons, offering a more clean look that does not overwhelm the player.

These changes are incredibly important to immerse the player into the domino playful aesthetic.

### **Turn Indicator Image:**
![image](https://github.com/user-attachments/assets/d4dafb4f-eeea-44f6-a528-e414f28ffc92)

### **Control Button and Volume Image:**
![image](https://github.com/user-attachments/assets/783c6949-a1a6-444a-b894-2f195b279ed8)
